### PR TITLE
fix visitors bagde

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <a href="https://stackoverflow.com/users/16315116/du%c5%a1an-stoki%c4%87"><img src="https://stackoverflow.com/users/flair/16315116.png?theme=dark" width="208" height="58" alt="profile for Dušan Stokić at Stack Overflow, Q&amp;A for professional and enthusiast programmers" title="profile for Dušan Stokić at Stack Overflow, Q&amp;A for professional and enthusiast programmers"></a>
 <a href="https://tex.stackexchange.com/users/245337/du%c5%a1an-stoki%c4%87"><img src="https://tex.stackexchange.com/users/flair/245337.png?theme=dark" width="208" height="58" alt="profile for Dušan Stokić at TeX - LaTeX Stack Exchange, Q&amp;A for users of TeX, LaTeX, ConTeXt, and related typesetting systems" title="profile for Dušan Stokić at TeX - LaTeX Stack Exchange, Q&amp;A for users of TeX, LaTeX, ConTeXt, and related typesetting systems"></a>
 
-[![Visits Badge](https://badges.pufler.dev/visits/stokicdusan/stokicdusan)](https://badges.pufler.dev/visits/stokicdusan/stokicdusan)
+[![Visits Badge](https://badges.strrl.dev/visits/StokicDusan/StokicDusan)](https://badges.strrl.dev)
 
 <!--
 <a href="https://stackexchange.com/users/22050789/du%c5%a1an-stoki%c4%87"><img src="https://stackexchange.com/users/flair/22050789.png" width="208" height="58" alt="profile for Dušan Stokić on Stack Exchange, a network of free, community-driven Q&amp;A sites" title="profile for Dušan Stokić on Stack Exchange, a network of free, community-driven Q&amp;A sites" /></a>


### PR DESCRIPTION
current visitors badge server is down.  
switching to: https://github.com/STRRL/serverless-github-badges